### PR TITLE
docs: add GitHub Pages publication plan

### DIFF
--- a/docs/GITHUB-PAGES-PUBLICATION.md
+++ b/docs/GITHUB-PAGES-PUBLICATION.md
@@ -1,0 +1,89 @@
+# GitHub Pages Publication Plan
+
+This document defines how CDLAN Portfolio will be published with GitHub Pages.
+
+GitHub Pages must not be activated until explicitly approved.
+
+## Expected public URL
+
+https://coderdeltalan.github.io/cdlan-portfolio/
+
+## Current status
+
+Pages is not enabled yet.
+
+The repository currently contains a safe placeholder page. The final landing page must be reviewed before publication.
+
+## Publication options
+
+### Option A — Publish placeholder
+
+Use this only if a temporary public presence is needed before the final landing page is ready.
+
+Requirements:
+
+- placeholder reviewed;
+- no secrets;
+- no private data;
+- no unfinished contact placeholders;
+- no fake claims;
+- CI green on main;
+- explicit approval before activation.
+
+### Option B — Wait for final landing page
+
+Preferred option.
+
+Use this if the final premium landing page will be integrated soon.
+
+Requirements:
+
+- final HTML reviewed;
+- content claims reviewed;
+- links reviewed;
+- contact reviewed;
+- accessibility basics reviewed;
+- mobile layout reviewed;
+- performance reviewed;
+- no secrets;
+- no tracking unless approved;
+- CI green on main;
+- explicit approval before activation.
+
+## Activation checklist
+
+Before enabling GitHub Pages:
+
+- main clean;
+- origin/main synchronized;
+- CI green for the exact main SHA;
+- index.html reviewed;
+- README and docs aligned;
+- no secrets;
+- no placeholders;
+- publication decision confirmed.
+
+## Source
+
+Expected source:
+
+- branch: main
+- path: root
+
+## Post-activation verification
+
+After enabling Pages:
+
+- verify Pages API status;
+- verify published URL;
+- verify no 404;
+- verify CSS loads;
+- verify JavaScript loads;
+- verify mobile rendering;
+- verify no private material is visible.
+
+## Rule
+
+Publishing is not a technical default.
+
+Publishing is a business decision.


### PR DESCRIPTION
Summary:
- Add a GitHub Pages publication plan.
- Document publication options, activation checklist, source and post-activation verification.

Scope:
- one documentation file
- no Pages activation
- no HTML changes
- no secrets
- no generated artifacts

Validation:
- local verification passed
- staged diff reviewed
- pre-push checks passed
- branch push verified