### PR TITLE
docs: add landing audit checklist

### DIFF
--- a/docs/LANDING-AUDIT-CHECKLIST.md
+++ b/docs/LANDING-AUDIT-CHECKLIST.md
@@ -1,0 +1,124 @@
+# Landing Audit Checklist
+
+This checklist must be completed before integrating or publishing the final CDLAN landing page.
+
+## Scope
+
+The final landing page may be visually premium, animated and commercial, but it must remain sober, defensible and safe.
+
+The current visual reference is not publishable until this checklist passes.
+
+## Content
+
+- No fake claims.
+- No exaggerated AI promises.
+- No invented clients.
+- No unsupported metrics.
+- No fake seniority.
+- No unverified prices.
+- No unverified tax claims.
+- No outdated model/version claims.
+- No unfinished placeholders.
+- No unapproved contact data.
+
+## Services
+
+The landing may describe:
+
+- applied AI systems;
+- automation;
+- RAG;
+- AI agents;
+- internal systems;
+- technical documentation;
+- static websites without backend for businesses, professionals and establishments.
+
+Every service must be described as an offer or capability, not as a proven client result unless evidence exists.
+
+## Beelink / local AI lab
+
+The Beelink SER8 may be described only as a local or hybrid laboratory until benchmarks and production validation exist.
+
+Do not claim:
+
+- production readiness;
+- private unlimited AI;
+- guaranteed performance;
+- fixed future RAM upgrades.
+
+Allowed wording:
+
+- hardware in incorporation;
+- benchmark pending;
+- local and hybrid AI lab;
+- possible future RAM upgrade if testing justifies it.
+
+## Security
+
+- No secrets.
+- No API keys.
+- No tokens.
+- No private prompts.
+- No real N8N workflow exports.
+- No backend internals.
+- No SaaS internals.
+- No client data.
+- No private commercial strategy.
+
+## Frontend
+
+- No external scripts unless reviewed.
+- No tracking unless explicitly approved.
+- No hidden data collection.
+- No backend dependency for first public version.
+- No broken CSS path.
+- No broken JavaScript path.
+- No console noise from unfinished code.
+
+## Contact
+
+- GitHub link confirmed.
+- Email confirmed before publication.
+- WhatsApp only if approved.
+- LinkedIn only if URL is confirmed.
+- No wa.me placeholder.
+- No fake form backend.
+
+## Accessibility
+
+- Page has a real title.
+- Meta description exists.
+- Main heading exists.
+- Text contrast is readable.
+- Mobile layout is usable.
+- Animations do not block reading.
+- Keyboard navigation is not broken.
+- Reduced-motion handling reviewed if heavy animation exists.
+
+## Performance
+
+- No oversized assets.
+- No unnecessary libraries.
+- No generated dependency folders committed.
+- No large media without review.
+- First public version should stay lightweight.
+
+## Publication
+
+Before Pages activation:
+
+- main clean;
+- origin/main synchronized;
+- CI green for exact SHA;
+- final HTML reviewed;
+- links reviewed;
+- contact reviewed;
+- no secrets;
+- no placeholders;
+- explicit approval given.
+
+## Rule
+
+Visual impact is welcome.
+
+False confidence is not.


### PR DESCRIPTION
Summary:
- Add a checklist for auditing the final CDLAN landing page before integration or publication.

Scope:
- one documentation file
- no HTML changes
- no Pages activation
- no secrets
- no generated artifacts

Validation:
- local verification passed
- staged diff reviewed
- pre-push checks passed
- branch push verified