### PR TITLE
chore: harden SEO and frontend metadata checks

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,17 +8,20 @@
      SEGURIDAD FRONTEND — POLÍTICAS BÁSICAS
 ═══════════════════════════════════════ -->
 <!-- Content Security Policy -->
-<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://fonts.googleapis.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://fonts.gstatic.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'none'; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'none';">
-<meta http-equiv="X-Content-Type-Options" content="nosniff">
-<meta http-equiv="X-Frame-Options" content="DENY">
-<meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=(), payment=(), usb=(), magnetometer=(), gyroscope=(), accelerometer=()">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://fonts.gstatic.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'none'; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'none';">
 <meta name="referrer" content="strict-origin-when-cross-origin">
-<meta http-equiv="X-XSS-Protection" content="1; mode=block">
+<meta name="color-scheme" content="dark">
+<meta name="theme-color" content="#000000">
 <!-- Políticas frontend básicas. La seguridad real depende también de cabeceras HTTP del hosting. -->
-<meta http-equiv="Cross-Origin-Opener-Policy" content="same-origin">
-<meta http-equiv="Cross-Origin-Resource-Policy" content="same-origin">
 <title>Yosvel Delta · CDLAN — IA Aplicada, Automatización, RAG y Webs Profesionales</title>
 <meta name="description" content="CDLAN / Yosvel Delta — IA aplicada, automatización, RAG, agentes IA y páginas web profesionales sin backend para negocios, profesionales y establecimientos. Tenerife Sur, Canarias. Sin humo. Sistemas útiles, documentados y mantenibles.">
+<meta name="author" content="Yosvel Delta / CDLAN">
+<meta name="robots" content="index, follow, max-image-preview:large">
+<link rel="canonical" href="https://coderdeltalan.github.io/cdlan-portfolio/">
+<meta property="og:title" content="Yosvel Delta · CDLAN — IA Aplicada, Automatización, RAG y Webs Profesionales">
+<meta property="og:description" content="IA aplicada, automatización, RAG, agentes IA y webs profesionales sin backend. Sistemas sobrios, útiles y mantenibles para negocios y profesionales.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://coderdeltalan.github.io/cdlan-portfolio/">
 <meta property="og:site_name" content="CDLAN · CoderDeltaLAN">
 <meta property="og:locale" content="es_ES">
 <meta property="og:locale:alternate" content="en_GB">
@@ -26,10 +29,9 @@
 <meta property="og:locale:alternate" content="fr_FR">
 
 <!-- TWITTER / X CARD -->
-<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:card" content="summary">
 <meta name="twitter:title" content="Yosvel Delta · CDLAN — IA Aplicada y Automatización">
 <meta name="twitter:description" content="IA aplicada, automatización, RAG, agentes IA y webs profesionales sin backend. Sistemas sobrios, útiles y mantenibles para negocios y profesionales.">
-<meta name="twitter:image:alt" content="CDLAN · Yosvel Delta · Consultor IA Tenerife">
 
 <!-- SCHEMA.ORG JSON-LD — DATOS ESTRUCTURADOS BÁSICOS -->
 <script type="application/ld+json">

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -70,6 +70,33 @@ if missing:
 print("[OK] index.html basic parse/check passed")
 PY
 
+printf '\n== SEO/security metadata check ==\n'
+seo_stop=0
+
+grep -Fq '<link rel="canonical" href="https://coderdeltalan.github.io/cdlan-portfolio/">' index.html || { printf '[FAIL] missing canonical\n'; seo_stop=1; }
+grep -Fq '<meta name="robots" content="index, follow, max-image-preview:large">' index.html || { printf '[FAIL] missing robots\n'; seo_stop=1; }
+grep -Fq '<meta name="author" content="Yosvel Delta / CDLAN">' index.html || { printf '[FAIL] missing author\n'; seo_stop=1; }
+grep -Fq '<meta property="og:title"' index.html || { printf '[FAIL] missing og:title\n'; seo_stop=1; }
+grep -Fq '<meta property="og:description"' index.html || { printf '[FAIL] missing og:description\n'; seo_stop=1; }
+grep -Fq '<meta property="og:type" content="website">' index.html || { printf '[FAIL] missing og:type\n'; seo_stop=1; }
+grep -Fq '<meta property="og:url" content="https://coderdeltalan.github.io/cdlan-portfolio/">' index.html || { printf '[FAIL] missing og:url\n'; seo_stop=1; }
+grep -Fq '<meta name="twitter:card" content="summary">' index.html || { printf '[FAIL] missing twitter summary card\n'; seo_stop=1; }
+grep -Fq '<meta name="theme-color" content="#000000">' index.html || { printf '[FAIL] missing theme-color\n'; seo_stop=1; }
+grep -Fq '<meta name="color-scheme" content="dark">' index.html || { printf '[FAIL] missing color-scheme\n'; seo_stop=1; }
+grep -Fq '<meta name="referrer" content="strict-origin-when-cross-origin">' index.html || { printf '[FAIL] missing referrer policy\n'; seo_stop=1; }
+grep -Fq 'Content-Security-Policy' index.html || { printf '[FAIL] missing Content-Security-Policy\n'; seo_stop=1; }
+
+if grep -Eq 'http-equiv="X-Frame-Options"|http-equiv="X-XSS-Protection"|http-equiv="Cross-Origin-Opener-Policy"|http-equiv="Cross-Origin-Resource-Policy"|http-equiv="Permissions-Policy"|http-equiv="X-Content-Type-Options"|summary_large_image|twitter:image' index.html; then
+  printf '[FAIL] misleading security/image metadata present\n'
+  seo_stop=1
+fi
+
+if [ "$seo_stop" -eq 0 ]; then
+  printf '[OK] SEO/security metadata passed\n'
+else
+  stop=1
+fi
+
 printf '\n== workflow trigger check ==\n'
 if grep -q 'chore/\*\*' .github/workflows/verify.yml && grep -q 'feat/\*\*' .github/workflows/verify.yml && grep -q 'fix/\*\*' .github/workflows/verify.yml && grep -q 'pull_request:' .github/workflows/verify.yml; then
   printf '[OK] workflow branch triggers found\n'


### PR DESCRIPTION
Hardens public metadata and repository verification.

Scope:
- add canonical, robots, author and Open Graph metadata;
- switch Twitter card to summary because there is no final social image yet;
- remove misleading http-equiv security metadata that GitHub Pages does not guarantee as real headers;
- tighten CSP script-src;
- add verify.sh checks for SEO/security metadata.

Constraints:
- README.md untouched;
- no backend;
- no secrets;
- no generated/vendor artifacts.

Local validation:
- scripts/verify.sh OK;
- git diff --check OK;
- pre-push validation OK.