### PR TITLE
chore: add docs branch trigger to verification workflow

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - chore/**
+      - docs/**
       - feat/**
       - fix/**
   pull_request:


### PR DESCRIPTION
Adds docs/** to the push branch triggers for the verification workflow.

Scope:
- update only .github/workflows/verify.yml;
- add docs/** to push branches;
- keep pull_request validation unchanged.

Reason:
- documentation branches were validated by pull_request checks;
- Always-Green discipline is stronger when docs/** push branches also create workflow runs.

Constraints:
- no README changes;
- no index.html changes;
- no assets changes;
- no documentation content changes;
- no generated/vendor artifacts.

Local validation:
- scripts/verify.sh OK;
- git diff --check OK;
- pre-push validation OK.